### PR TITLE
Re-add dumping static methods

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -252,6 +252,12 @@ subprojects {
             downloadJson.dest.json.libraries.stream().map{ it?.downloads?.artifact?.path }.findAll{ it != null }.each{ library(file(PATH_CACHED_LIBRARIES + it)) }
         }
     }
+    
+    task dumpStatic(type: DumpStatics, dependsOn: extractInheritance) {
+        srg file('joined.tsrg')
+        meta extractInheritance.dest
+        dest file(PATH_CACHED_VERSION_DATA + 'static_methods.txt')
+    }
 
     task dumpOverrides(type: DumpOverrides, dependsOn: [extractInheritance, makeObfToIntermediate]) {
         srg makeObfToIntermediate.dest
@@ -631,6 +637,11 @@ subprojects {
 
         from generateConfiguration
         from(file('joined.tsrg')){ into 'config/' }
+        
+        if (MC_VERSION.compareTo(MC_1_16_5) < 0) {
+            dependsOn dumpStatic
+            from(dumpStatic){ into 'config/' }
+        }
 
         def access = file('access.txt')
         if (access.exists()) from(access) { into 'config/' }

--- a/buildSrc/src/main/groovy/net/minecraftforge/mcpconfig/tasks/DumpStatics.groovy
+++ b/buildSrc/src/main/groovy/net/minecraftforge/mcpconfig/tasks/DumpStatics.groovy
@@ -1,0 +1,35 @@
+package net.minecraftforge.mcpconfig.tasks
+
+import groovy.json.JsonSlurper
+import net.minecraftforge.srgutils.IMappingFile
+import org.gradle.api.tasks.InputFile
+import org.gradle.api.tasks.TaskAction
+import static org.objectweb.asm.Opcodes.ACC_STATIC
+
+public class DumpStatics extends SingleFileOutput {
+    @InputFile File srg
+    @InputFile File meta
+    
+    @TaskAction
+    protected void exec() {
+        def srgO = IMappingFile.load(srg)
+        def json = new JsonSlurper().parseText(meta.text)
+        
+        def methods = [] as HashSet
+
+        json.each{ cls,data ->
+            data['methods']?.findAll{k,v -> (v['access'] & ACC_STATIC) != 0}.each{ __, method ->
+                def name = method['name']
+                def desc = method['desc']
+                def mapped = srgO.getClass(cls)?.remapMethod(name, desc)
+                if (mapped != null && !desc.contains('()') && mapped.contains('func_'))
+                    methods.add(mapped)
+            }
+        }
+
+        dest.withWriter('UTF-8') { writer ->
+            methods = methods.sort{it}
+            methods.each{ writer.write(it + '\n') }
+        }
+    }
+}


### PR DESCRIPTION
Re-add the `dumpStatic` task as used in bb42630 and earlier, configured to run on versions older than 1.16.5.  
This fixes parameter IDs of static methods in generated patches.