### PR TITLE
Remove mergetool api from libraries

### DIFF
--- a/versions/release/1.11.2/config.json
+++ b/versions/release/1.11.2/config.json
@@ -22,6 +22,6 @@
     "libraries" : {
         "client" : [ "com.google.code.findbugs:jsr305:3.0.1" ],
         "server" : [ "com.google.code.findbugs:jsr305:3.0.1" ],
-        "joined" : [ "com.google.code.findbugs:jsr305:3.0.1", "net.minecraftforge:mergetool:0.2.3.2:forge" ]
+        "joined" : [ "com.google.code.findbugs:jsr305:3.0.1" ]
     }
 }


### PR DESCRIPTION
Removes the mergetool api from MCPConfig libraries, because it's not used anywhere.

The mergetool runtime used during setup already includes the api, and 1.11 forge ships the side api classes as well.
By removing this dependency, we also fix 2 issues related to FG runs:

#### Mergetool api classes conflicting with forge

If mergetool's `Side` class is loaded first, it will crash `NetworkRegistry` which only expects `CLIENT` and `SERVER` sides to exist, while this version also contains `BUKKIT`.

#### Mod discoverer `IllegalArgumentException`

Mergetool api depends on ASM 6, which contains a module descriptor. If FML tries to scan that module descriptor with its older version of ASM, it will throw an exception.